### PR TITLE
[3주차] 스핀락으로 ConcurrentHashMap구현

### DIFF
--- a/3week/3주차.md
+++ b/3week/3주차.md
@@ -1,0 +1,9 @@
+
+
+1. ConcurrentHashMap의 Size 어떻게 스레드스에프하게 구현되었는지 조사
+   2. https://github.com/yujunpapa/TIL/blob/main/java/concurrent-hashmap/size%EB%8F%99%EC%9E%91%EC%9B%90%EB%A6%AC.md
+   2. size()메서드의 동시성 테스트를 위해서는 remove,put이 일어나는 중간에 size값이 즉시반영되는지를 확인해야하는데, 이를 테스트코드로 작성하기가 쉽지 않네요, 단순하게 예상하는 size와 최종 size를 비교하는건 가능할텐데 경합상황에서 size가 잘 나오는지 테스트하는게 가능한지 궁금합니다.
+3. ConcurrentHashMap을 스핀락형태로 구현
+   4. SpinLockUtil에 구현
+
+    

--- a/src/main/kotlin/kr/flab/f5/f5template/lecture/week2/Lecture1HashMap.kt
+++ b/src/main/kotlin/kr/flab/f5/f5template/lecture/week2/Lecture1HashMap.kt
@@ -1,31 +1,57 @@
 package kr.flab.f5.f5template.lecture.week2
 
-class Lecture1HashMap<K, V> : java.util.Map<K, V> {
 
+import java.util.concurrent.ConcurrentHashMap
+import java.util.concurrent.atomic.AtomicInteger
+
+class Lecture1HashMap<K, V> : java.util.Map<K, V> {
     private val innerMap = HashMap<K, V>()
+    private val atomicCounter = AtomicInteger(0)
+    private val spinLock = SpinLockUtil.getInstance<K>()
+
 
     override fun get(key: Any?): V? {
-        return innerMap[key]
+        return spinLock.withLock(key) {
+            innerMap[key]
+        }
     }
 
     override fun put(key: K, value: V): V? {
-        return innerMap.put(key, value)
+        return spinLock.withLock(key) {
+            val result = innerMap.put(key, value)
+            if (result == null) {
+                atomicCounter.incrementAndGet()
+            }
+            result
+        }
     }
 
     override fun remove(key: Any?): V? {
-        return innerMap.remove(key)
+        return spinLock.withLock(key) {
+            val result = innerMap.remove(key)
+            if (result != null) {
+                atomicCounter.decrementAndGet()
+            }
+            result
+        }
     }
 
     override fun putIfAbsent(key: K, value: V): V? {
-        return innerMap.putIfAbsent(key, value)
+        return spinLock.withLock(key) {
+            val result = innerMap.putIfAbsent(key, value)
+            if (result == null) {
+                atomicCounter.incrementAndGet()
+            }
+            result
+        }
     }
 
     override fun size(): Int {
-        return innerMap.size
+        return atomicCounter.get()
     }
 
     override fun isEmpty(): Boolean {
-        return innerMap.isEmpty()
+       return atomicCounter.get() == 0
     }
 
     // ------- 이 아래는 구현하지 않으셔도 됩니다 ----------

--- a/src/main/kotlin/kr/flab/f5/f5template/lecture/week2/SpinLockUtil.kt
+++ b/src/main/kotlin/kr/flab/f5/f5template/lecture/week2/SpinLockUtil.kt
@@ -1,0 +1,71 @@
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicReference
+
+/**
+ * SpinLockUtil을 사용하는 관점에서 SpinLockUtil이 여러개의 인스턴스로 만들어지면 이를 사용하는 코드에서는 개발자의 실수로 SpinLockUtil여러개를 생성해서 사용할 수 있다.
+ * 이런 경우에는 동시성보장이 힘들다. 따라서 싱글톤으로 객체생성을 진행하도록 했다. 
+ */
+class SpinLockUtil<T> private constructor(private val lockSize: Int) {
+    private val locks = Array(lockSize) { AtomicReference<Thread?>(null) }
+
+    companion object {
+        private var instance: SpinLockUtil<Any>? = null
+
+        @Synchronized
+        @Suppress("UNCHECKED_CAST")
+        fun <T> getInstance(lockSize: Int = 16): SpinLockUtil<T> {
+            if (instance == null || instance!!.lockSize != lockSize) {
+                instance = SpinLockUtil(lockSize)
+            }
+            return instance as SpinLockUtil<T>
+        }
+    }
+
+    private fun getLockIndex(key: Any?): Int {
+        return key.hashCode() % lockSize
+    }
+
+    private fun getLock(key: Any?): AtomicReference<Thread?> {
+        val index = getLockIndex(key)
+        return locks[index]
+    }
+
+    fun acquireLock(
+        key: Any?,
+        maxRetryCount: Int = -1,
+        timeout: Long = 0,
+        unit: TimeUnit = TimeUnit.MILLISECONDS
+    ): Boolean {
+        val lock = getLock(key)
+        var retryCount = 0
+        while (retryCount < maxRetryCount || maxRetryCount == -1) {
+            if (lock.compareAndSet(null, Thread.currentThread())) {
+                return true
+            }
+            if (timeout > 0) {
+                Thread.sleep(unit.toMillis(timeout))
+            }
+            retryCount++
+        }
+        return false
+    }
+
+    fun releaseLock(key: Any?) {
+        val lock = getLock(key)
+        if (lock.get() !== Thread.currentThread()) {
+            throw Exception("release 실패, lock을 가지고 있지 않습니다.")
+        }
+        lock.set(null)
+    }
+
+    fun <R> withLock(key: Any?, block: () -> R): R? {
+        try {
+            if (acquireLock(key)) {
+                return block()
+            }
+        } finally {
+            releaseLock(key)
+        }
+        return null
+    }
+}

--- a/src/test/kotlin/kr/flab/f5/f5template/lecture/week2/Lecture1HashMapTest.kt
+++ b/src/test/kotlin/kr/flab/f5/f5template/lecture/week2/Lecture1HashMapTest.kt
@@ -1,0 +1,61 @@
+package kr.flab.f5.f5template.lecture.week2
+import org.assertj.core.api.Assertions.assertThat
+import org.junit.jupiter.api.Test
+
+import org.junit.jupiter.api.Assertions.*
+import java.util.concurrent.CountDownLatch
+import java.util.concurrent.Executors
+import java.util.concurrent.TimeUnit
+import java.util.concurrent.atomic.AtomicInteger
+
+class Lecture1HashMapTest {
+
+    private val executor = Executors.newCachedThreadPool()
+    private val executionCount = 100
+    
+    
+    @Test
+    fun `set,remove operation을 동시에 실행하면 최종 상태가 올바르게 반영된다`() {
+        val concurrentHashMap = Lecture1HashMap<Int,Int>()
+        concurrentHashMap.put(1,1)
+        concurrentHashMap.put(2,2)
+        concurrentHashMap.put(3,3)
+        var initialSize = 3;
+
+        val tasks = listOf(
+            Runnable {
+                concurrentHashMap.put(4,4)
+            },
+            Runnable {
+                concurrentHashMap.remove(4)
+            },
+
+        )
+
+        tasks.forEach { executor.submit(it) }
+        executor.shutdown()
+        executor.awaitTermination(1, TimeUnit.SECONDS)
+        assertThat(concurrentHashMap.size()).isEqualTo(initialSize)
+
+    }
+
+    @Test
+    fun put() {
+    }
+
+    @Test
+    fun remove() {
+    }
+
+    @Test
+    fun putIfAbsent() {
+    }
+
+    @Test
+    fun size() {
+    }
+
+    @Test
+    fun isEmpty() {
+    }
+}


### PR DESCRIPTION
[3주차] 스핀락으로 ConcurrentHashMap구현

1. ConcurrentHashMap의 Size 어떻게 스레드스에프하게 구현되었는지 조사
   -  https://github.com/yujunpapa/TIL/blob/main/java/concurrent-hashmap/size%EB%8F%99%EC%9E%91%EC%9B%90%EB%A6%AC.md
   -  size()메서드의 동시성 테스트를 위해서는 remove,put이 일어나는 중간에 size값이 즉시반영되는지를 확인해야하는데, 이를 테스트코드로 작성하기가 쉽지 않네요, 단순하게 예상하는 size와 최종 size를 비교하는건 가능할텐데 경합상황에서 size가 잘 나오는지 테스트하는게 가능한지 궁금합니다.
2. ConcurrentHashMap을 스핀락형태로 구현
   -  SpinLockUtil에 구현